### PR TITLE
Potential fix for code scanning alert no. 1: Disabled Spring CSRF protection

### DIFF
--- a/services/user-management/src/main/java/com/beartrail/user/config/SecurityConfig.java
+++ b/services/user-management/src/main/java/com/beartrail/user/config/SecurityConfig.java
@@ -29,7 +29,6 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/login", "/api/auth/register").permitAll()


### PR DESCRIPTION
Potential fix for [https://github.com/georgereuben/beartrail/security/code-scanning/1](https://github.com/georgereuben/beartrail/security/code-scanning/1)

To fix the problem, CSRF protection should be enabled by default. This means removing or modifying the line that disables CSRF protection (`.csrf(AbstractHttpConfigurer::disable)`). If there are endpoints that must be accessible without CSRF protection (e.g., for non-browser clients), those should be explicitly configured, but by default, CSRF should be enabled. In this case, simply removing the `.csrf(AbstractHttpConfigurer::disable)` call from the `filterChain` method will restore Spring Security's default CSRF protection. No additional imports or method definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
